### PR TITLE
bump JWT dependency to github.com/golang-jwt/jwt/v4

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 
 	env "github.com/dangersalad/go-environment"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/dangersalad/go-commonerror"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 var defaultCookieName = "auth-jwt"

--- a/context.go
+++ b/context.go
@@ -2,7 +2,7 @@ package user
 
 import (
 	"context"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"net/http"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dangersalad/go-user
 require (
 	github.com/dangersalad/go-commonerror v0.1.2
 	github.com/dangersalad/go-environment v0.2.2
-	github.com/dgrijalva/jwt-go v0.0.0-20180308231308-06ea1031745c
+	github.com/golang-jwt/jwt/v4 v4.4.3
 	golang.org/x/crypto v0.0.0-20180509205747-2d027ae1dddd
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/dangersalad/go-commonerror v0.1.2 h1:Pw8lXf6nN0YP7N5i4GqELWQtZxbcKoRO
 github.com/dangersalad/go-commonerror v0.1.2/go.mod h1:vTQLRbjbjDM1bzLHt9vDGgHjfGbK12h+KKI5D+5655M=
 github.com/dangersalad/go-environment v0.2.2 h1:23nH+FkhfEnQjU5b/WweWHjJgs24dsLRkqElxHi9Lnk=
 github.com/dangersalad/go-environment v0.2.2/go.mod h1:tq28E5WUhlOKAY5d2nbTFk0i0E6MnGjzLLNCR0Lo4dE=
-github.com/dgrijalva/jwt-go v0.0.0-20180308231308-06ea1031745c h1:uwivskbBuX2rEOnl6mwlyJ4oql65nBku08q0NfLAryM=
-github.com/dgrijalva/jwt-go v0.0.0-20180308231308-06ea1031745c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 golang.org/x/crypto v0.0.0-20180509205747-2d027ae1dddd h1:SuDTjBhSMCPRh1JuhAAzDbwSCwXa8pv17NTDcIvC1AQ=
 golang.org/x/crypto v0.0.0-20180509205747-2d027ae1dddd/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/login.go
+++ b/login.go
@@ -2,7 +2,7 @@ package user
 
 import (
 	"encoding/base64"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"net/http"
 	"regexp"
 	"strings"


### PR DESCRIPTION
github.com/dgrijalva/jwt-go is no longer maintained, see: https://github.com/dgrijalva/jwt-go#this-repository-is-no-longer-maintaned

Bump to the latest version of the maintained, and backwards compatible github.com/golang-jwt/jwt library.